### PR TITLE
Pipe public files through Drupal, so they get CORS

### DIFF
--- a/shoov/modules/custom/shoov_restful/plugins/restful/file/screenshots_upload/1.0/screenshots_upload__1_0.inc
+++ b/shoov/modules/custom/shoov_restful/plugins/restful/file/screenshots_upload/1.0/screenshots_upload__1_0.inc
@@ -8,12 +8,13 @@ if (variable_get('restful_file_upload', FALSE)) {
     'class' => 'ShoovScreenshotsUploadResource',
     'entity_type' => 'file',
     'authentication_types' => TRUE,
-    // @todo: Remove.
-    'authentication_optional' => variable_get('restful_file_upload_allow_anonymous_user', FALSE),
     // We will implement hook_menu() with custom settings.
     'menu_item' => variable_get('restful_hook_menu_base_path', 'api') . '/screenshots-upload',
     // Set the default validators, scheme, and replace as used in
     // file_save_upload().
-    'options' => array(),
+    'options' => array(
+      // Use our "piped" stream wrapper.
+      'scheme' => 'piped',
+    ),
   );
 }

--- a/shoov/modules/custom/shoov_restful/shoov_restful.module
+++ b/shoov/modules/custom/shoov_restful/shoov_restful.module
@@ -43,24 +43,3 @@ function shoov_restful_get_user_token($account = NULL)  {
 
   return $entity->token;
 }
-
-/**
- * Implements hook_file_download_access().
- *
- * Get the user account from the RESTful authentication.
- */
-function shoov_restful_file_download_access($file_item, $entity_type, $entity) {
-  $auth_plugins = array_keys(restful_get_authentication_plugins());
-
-  $auth_manager = new RestfulAuthenticationManager();
-
-  // Register all authentication plugins.
-  foreach ($auth_plugins as $auth_plugin_name) {
-    $auth_handler = restful_get_authentication_handler($auth_plugin_name);
-    $auth_manager->addAuthenticationProvider($auth_handler);
-    $auth_manager->setIsOptional(TRUE);
-  }
-
-  $request = restful_parse_request();
-  $auth_manager->getAccount($request);
-}

--- a/shoov/modules/custom/shoov_screenshot/includes/ShoovPipedStreamWrapper.php
+++ b/shoov/modules/custom/shoov_screenshot/includes/ShoovPipedStreamWrapper.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Public piped (piped://) stream wrapper class.
+ */
+class ShoovPipedStreamWrapper extends DrupalLocalStreamWrapper {
+  /**
+   * Implements abstract public function getDirectoryPath()
+   */
+  public function getDirectoryPath() {
+    return variable_get('file_public_path', conf_path() . '/files');
+  }
+
+  /**
+   * Overrides getExternalUrl().
+   *
+   * Return the HTML URI of a private file.
+   */
+  function getExternalUrl() {
+    $path = str_replace('\\', '/', $this->getTarget());
+    return url('shoov/images/' . $path, array('absolute' => TRUE));
+  }
+}

--- a/shoov/modules/custom/shoov_screenshot/shoov_screenshot.features.field_base.inc
+++ b/shoov/modules/custom/shoov_screenshot/shoov_screenshot.features.field_base.inc
@@ -34,7 +34,7 @@ function shoov_screenshot_field_default_field_bases() {
     'module' => 'image',
     'settings' => array(
       'default_image' => 0,
-      'uri_scheme' => 'public',
+      'uri_scheme' => 'piped',
     ),
     'translatable' => 0,
     'type' => 'image',
@@ -129,7 +129,7 @@ function shoov_screenshot_field_default_field_bases() {
     'module' => 'image',
     'settings' => array(
       'default_image' => 0,
-      'uri_scheme' => 'public',
+      'uri_scheme' => 'piped',
     ),
     'translatable' => 0,
     'type' => 'image',
@@ -159,7 +159,7 @@ function shoov_screenshot_field_default_field_bases() {
     'module' => 'image',
     'settings' => array(
       'default_image' => 0,
-      'uri_scheme' => 'public',
+      'uri_scheme' => 'piped',
     ),
     'translatable' => 0,
     'type' => 'image',

--- a/shoov/modules/custom/shoov_screenshot/shoov_screenshot.info
+++ b/shoov/modules/custom/shoov_screenshot/shoov_screenshot.info
@@ -37,6 +37,5 @@ features[variable][] = menu_parent_screenshot
 features[variable][] = node_options_screenshot
 features[variable][] = node_preview_screenshot
 features[variable][] = node_submitted_screenshot
-mtime = 1427573593
-
 files[] = includes/ShoovPipedStreamWrapper.php
+mtime = 1427876265

--- a/shoov/modules/custom/shoov_screenshot/shoov_screenshot.info
+++ b/shoov/modules/custom/shoov_screenshot/shoov_screenshot.info
@@ -38,3 +38,5 @@ features[variable][] = node_options_screenshot
 features[variable][] = node_preview_screenshot
 features[variable][] = node_submitted_screenshot
 mtime = 1427573593
+
+files[] = includes/ShoovPipedStreamWrapper.php

--- a/shoov/modules/custom/shoov_screenshot/shoov_screenshot.module
+++ b/shoov/modules/custom/shoov_screenshot/shoov_screenshot.module
@@ -7,13 +7,77 @@
 include_once 'shoov_screenshot.features.inc';
 
 /**
- * Implements hook_menu_alter().
+ * Implements hook_menu().
  *
- * We set the file download to be private but in fact just use it to pipe the
- * request through Drupal.
+ * Add a piped public files download.
  * This is a temporary hack as Pantheon doesn't allow sending CORS on public
  * files.
  */
-function shoov_screenshot_menu_alter(&$items) {
-  $items['system/files']['page arguments'] = array('public');
+function shoov_screenshot_menu() {
+  $items['shoov/images'] = array(
+    'title' => 'Images download',
+    'page callback' => 'shoov_screenshot_file_download',
+    'page arguments' => array('piped'),
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
 }
+
+/**
+ *
+ * @see system_menu()
+ */
+function shoov_screenshot_file_download() {
+  // Merge remainder of arguments from GET['q'], into relative file path.
+  $args = func_get_args();
+  $scheme = array_shift($args);
+  $target = implode('/', $args);
+  $uri = $scheme . '://' . $target;
+  if (file_stream_wrapper_valid_scheme($scheme) && file_exists($uri)) {
+
+    $files = file_load_multiple(array(), array('uri' => $uri));
+    if (count($files)) {
+      foreach ($files as $item) {
+        // Since some database servers sometimes use a case-insensitive comparison
+        // by default, double check that the filename is an exact match.
+        if ($item->uri === $uri) {
+          $file = $item;
+          break;
+        }
+      }
+    }
+    if (!isset($file)) {
+      return;
+    }
+
+    $headers = array(
+      'Content-Type' => mime_header_encode($file->filemime),
+      'Content-Length' => $file->filesize,
+    );
+
+    file_transfer($uri, $headers);
+  }
+  else {
+    drupal_not_found();
+  }
+  drupal_exit();
+}
+
+/**
+ * Implements hook_stream_wrappers().
+ */
+function shoov_screenshot_stream_wrappers() {
+  $wrappers = array(
+    'piped' => array(
+      'name' => t('Shoov images'),
+      'class' => 'ShoovPipedStreamWrapper',
+      'description' => t('Piped public local files served by Drupal.'),
+      'type' => STREAM_WRAPPERS_LOCAL_NORMAL,
+    ),
+  );
+
+  return $wrappers;
+}
+

--- a/shoov/modules/custom/shoov_screenshot/shoov_screenshot.module
+++ b/shoov/modules/custom/shoov_screenshot/shoov_screenshot.module
@@ -5,3 +5,15 @@
  */
 
 include_once 'shoov_screenshot.features.inc';
+
+/**
+ * Implements hook_menu_alter().
+ *
+ * We set the file download to be private but in fact just use it to pipe the
+ * request through Drupal.
+ * This is a temporary hack as Pantheon doesn't allow sending CORS on public
+ * files.
+ */
+function shoov_screenshot_menu_alter(&$items) {
+  $items['system/files']['page arguments'] = array('public');
+}

--- a/shoov/modules/custom/shoov_screenshot/shoov_screenshot.module
+++ b/shoov/modules/custom/shoov_screenshot/shoov_screenshot.module
@@ -26,8 +26,9 @@ function shoov_screenshot_menu() {
 }
 
 /**
- *
- * @see system_menu()
+ * Pipe public files to be served from Drupal.
+ * 
+ * @see file_donwload()
  */
 function shoov_screenshot_file_download() {
   // Merge remainder of arguments from GET['q'], into relative file path.


### PR DESCRIPTION
This is in fact a hack, as Pantheon which is used for the hosting doesn't allow having CORS on public files.

The files aren't served as private for performance reasons, but instead the file name would be obscured - the same as Github is doing for the images on private repos.
