### PR TITLE
Fix bug with empty arguments for first message when newly ci build is created.

### DIFF
--- a/shoov/modules/custom/shoov_ci_build/shoov_ci_build.module
+++ b/shoov/modules/custom/shoov_ci_build/shoov_ci_build.module
@@ -159,7 +159,12 @@ function shoov_ci_build_create_build_item($node, $timestamp = NULL) {
 
   $timestamp = $timestamp ?: time();
 
-  $message = message_create('ci_build', array('uid' => $node->uid));
+  $arguments = array(
+    '@{message:field-ci-build:og-repo}' => $wrapper->og_repo->label(),
+    '@{message:field-ci-build:field_git_branch}' => $wrapper->field_git_branch->value(),
+  );
+
+  $message = message_create('ci_build', array('uid' => $node->uid, 'arguments' => $arguments));
   $wrapper = entity_metadata_wrapper('message', $message);
   $wrapper->field_ci_build->set($node);
   $wrapper->field_ci_build_status->set('queue');


### PR DESCRIPTION
When i create a new CI build then new message created automatically but without arguments. This path fix that. 

Merge please.

![selection_109](https://cloud.githubusercontent.com/assets/10127295/8451908/7baf0fb6-1fef-11e5-80f4-7e2cc26ffbde.png)
