### PR TITLE
Remove grunt version from the package.json.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,6 @@
     "grunt-s3": "^0.2.0-alpha.3"
   },
   "devDependencies": {
-    "grunt": "^0.4.1",
     "grunt-autoprefixer": "^0.7.3",
     "grunt-aws-s3": "^0.13.0",
     "grunt-build-control": "^0.2.2",


### PR DESCRIPTION
The `grunt` causes problems with different `npm` versions. After removing - `npm install` works fine and `grunt serve` doesn't return the error.
